### PR TITLE
Update XJTU-thesis.cls

### DIFF
--- a/XJTU-thesis.cls
+++ b/XJTU-thesis.cls
@@ -1380,7 +1380,7 @@
   \addcontentsline{toc}{chapter}{参考文献}
   \addcontentsline{toe}{chapter}{References}
   \hypersetup{bookmarksdepth=2}
-  \nocite{*}
+%   \nocite{*}
   \printbibliography[heading=bibliography,title=\thesisbibname]
   \pagecheck
 }


### PR DESCRIPTION
Bug: 文中没有引用的文献会出现在文末的参考文献中
原因分析：正常来说使用bib文件来引用参考文献，如果没有引用的话，是不会显示的，如果需要全部显示需要加入 \notice{*}才能达到此种效果。