### PR TITLE
修复 Linux 下编译不通过的问题

### DIFF
--- a/LaTeX_Template/XJTU-thesis.cls
+++ b/LaTeX_Template/XJTU-thesis.cls
@@ -280,12 +280,7 @@
     \setCJKmainfont[AutoFakeBold=true]{FandolSong}
     \newfontfamily{\heiti@letter}{FandolHei}
     \newfontfamily{\songti@letter}{FandolSong}
-    \setmainfont[
-      BoldFont=timesbd.ttf,
-      ItalicFont=timesi.ttf,
-      BoldItalicFont=timesbi.ttf,
-      Path=/usr/local/share/fonts/,
-    ]{times.ttf}
+    \setmainfont{XITS}
     \setmathfont{XITS Math}
   \fi
 \fi

--- a/LaTeX_Template/main.tex
+++ b/LaTeX_Template/main.tex
@@ -1,9 +1,9 @@
 % !TEX program = latexmk
 % !TEX encoding = UTF-8 Unicode
 
-% 注意：请使用 TeXLive 2019 及以上版本，已在 2019 2020 2021 版本测试编译成功，已在 2018 测试编译失败
+% 注意：请使用 TeXLive 2020 及以上版本，已在 2020 2021 版本测试编译成功，已在 2019 测试编译失败
 % 如不想更新，可尝试使用 手动编译 XeLaTeX（可能出错）
-% WARNING: Please use TeXLive version >= 2019, This template has been tested and found available on 2019, 2020, 2021, unavailable on 2018. 
+% WARNING: Please use TeXLive version >= 2020, This template has been tested and found available on 2020, 2021, unavailable on 2019. 
 
 % 注意：请确保自己已经完整阅读了 README.md 这一 markdown 文档，部分功能的使用方法并未在 .tex 中直接给出；如果仍有使用问题，请在 Github 上提出 issue
 % WARNING: Pleans read README.md first cause some usages are not given in .tex files.


### PR DESCRIPTION
1. 在 texlive 2019 中，`\gencommitteelist` 会报错，应该是用到的哪个命令当时还未定义，因此修改了 tex 文件中的注释
2. 将 Linux 调用的字体设置成 `XITS`，这样在 Overleaf 就能编译通过了