### PR TITLE
关于本科模板下论文摘要bug的一些微小修复

### DIFF
--- a/XJTU-thesis.cls
+++ b/XJTU-thesis.cls
@@ -1051,11 +1051,19 @@
 }
 
 \newcommand{\chskeywords}{\fontsize{12pt}{12pt}\selectfont \bfseries 关~~键~~词：}
-\newcommand{\chstypeofthesis}{\fontsize{12pt}{12pt}\selectfont \bfseries 论文类型：}
 \newcommand{\engkeywords}{\fontsize{12pt}{12pt}\selectfont \bfseries KEY WORDS:}
-\newcommand{\engtypeofthesis}{\fontsize{12pt}{12pt}\selectfont \bfseries TYPE OF \englishthesistypea:}
-\newcommand{\chinesekeywordstype}[2]{\keywordswithtype{\chskeywords}{\chstypeofthesis}{#1}{#2}}
-\newcommand{\englishkeywordstype}[2]{\keywordswithtype{\engkeywords}{\engtypeofthesis}{#1}{#2}}
+
+\iftyp@bachelor
+  \newcommand{\chstypeofthesis}{\fontsize{12pt}{12pt}\selectfont \bfseries}
+  \newcommand{\engtypeofthesis}{\fontsize{12pt}{12pt}\selectfont \bfseries}
+  \newcommand{\chinesekeywordstype}[2]{\keywordswithtype{\chskeywords}{\chstypeofthesis}{#1}}
+  \newcommand{\englishkeywordstype}[2]{\keywordswithtype{\engkeywords}{\engtypeofthesis}{#1}}
+\else
+  \newcommand{\chstypeofthesis}{\fontsize{12pt}{12pt}\selectfont \bfseries 论文类型：}
+  \newcommand{\engtypeofthesis}{\fontsize{12pt}{12pt}\selectfont \bfseries TYPE OF \englishthesistypea:}
+  \newcommand{\chinesekeywordstype}[2]{\keywordswithtype{\chskeywords}{\chstypeofthesis}{#1}{#2}}
+  \newcommand{\englishkeywordstype}[2]{\keywordswithtype{\engkeywords}{\engtypeofthesis}{#1}{#2}}
+\fi
 
 \renewcommand{\thesisabstract}{
   \pagestyle{fancy}

--- a/main.tex
+++ b/main.tex
@@ -13,8 +13,8 @@
 %% 选择论文的基本类型
 
 \documentclass[
-    doctor,     % 必选项：   {master, doctor} 此处不区分专业/学术学位，在下面学科类型处区分
-                % Mandatory: {master, doctor} No difference between Academic degree and Professional degree,
+    bachelor,   % 必选项：   {bachelor,master, doctor} 此处不区分专业/学术学位，在下面学科类型处区分
+                % Mandatory: {bachelor,master, doctor} No difference between Academic degree and Professional degree,
                 %                             but be careful about arguments in `\degree' and `\subject'
     % english,  % 可选项：   英文正文请选择此项
                 % Optional:  For english main content, It will change some auto-generated matter into English
@@ -36,6 +36,7 @@
 
 % 学位类型
 % Type of your degree, Translate it from documents in `Materials/Requirements/2021/01 中英文题名页示例/英文标准翻译/'
+%\degree{学士}{Engineering}
 %\degree{硕士}{Engineering} % 学术型(Academic)硕士请基于 '学术学位名称.txt' 填写
 \degree{硕士}{Engineering} % 专业型(Professional)硕士请基于 '专业学位（领域）英文标准翻译.pdf' 填写
 %\degree{博士}{Philosophy}  % 学术型(Academic Doc)博士请填写 '{博士}{Philosophy}'


### PR DESCRIPTION
将模板设定为bachelor后编译报错，显示在**abstract_eng.tex**中的 \englishkeywordstyp 为非控制符
查阅cls模板后发现问题：
在变量部分（原文件428行处）master与doctor有预设变量 \def\englishthesistypea ，而bachelor并没有预设变量导致报错
根据官方给本科毕设[http://due.xjtu.edu.cn/info/1040/2802.htm](url)所给出的模板中并无论文类型一项，是故将其消去。