### PR TITLE
修复指定输出目录时`latexmk`的错误

### DIFF
--- a/LaTeX_Template/latexmkrc
+++ b/LaTeX_Template/latexmkrc
@@ -9,12 +9,16 @@ add_cus_dep('glo', 'gls', 0, 'run_makeglossaries');
 add_cus_dep('acn', 'acr', 0, 'run_makeglossaries');
 
 sub run_makeglossaries {
+  my ($base_name, $path) = fileparse( $_[0] );
+  pushd $path;
   if ( $silent ) {
-    system "makeglossaries -q $_[0]";
+    my $return = system "makeglossaries -q $base_name";
   }
   else {
-    system "makeglossaries $_[0]";
+    my $return = system "makeglossaries $base_name";
   };
+  popd;
+  return $return;
 }
 
 push @generated_exts, 'glo', 'gls', 'glg';


### PR DESCRIPTION
目前的`latexmkrc`文件默认输出为项目根目录，执行`latexmk`时结果正常。
但如果想将输出和临时文件置于其他目录（如`build`目录，执行`latexmk -outdir=build`），则会提示`makeglossaries`脚本出错。

本PR根据[这里](https://tex.stackexchange.com/questions/58963/latexmk-with-makeglossaries-and-auxdir-and-outdir)提供的方案对`latexmkrc`文件进行了修改，确保了在指定输出目录后仍然能得到一致的结果。