### PR TITLE
实现无常规评审人的代码存在多余的冒号

### DIFF
--- a/XJTU-thesis.cls
+++ b/XJTU-thesis.cls
@@ -1757,7 +1757,7 @@
     。
   \else
     ，名单如下：
-  \fi：
+  \fi
   \ifthesis@blind\else
     \renewcommand{\arraystretch}{1.5}
     \begin{table}[H]


### PR DESCRIPTION
提交 1779893 在实现 #141 中描述的功能时，在`XJTU-thesis.cls`的[1760行](https://github.com/obster-y/XJTU-thesis/blob/1779893b6774e10512302490405f198cb84037aa/XJTU-thesis.cls#L1760)存在一个多余的冒号，此PR将该冒号进行删除。